### PR TITLE
Use `id` from Session.

### DIFF
--- a/src/snex.js
+++ b/src/snex.js
@@ -27,7 +27,7 @@ class Session extends EventEmitter
         'Content-Type': 'application/json'
       }),
       body: JSON.stringify({
-        id: this.peer.id,
+        id: this.id,
         type: pad,
         key: 'deprecated',
       }),


### PR DESCRIPTION
See if it mitigates https://github.com/snex-io/snex-lib/issues/3 or perhaps a new Peer connection should be created.