### PR TITLE
Explicit json serialization.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "snex",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "snex",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Library for listening to input from SNEX gamepads.",
   "license": "MIT",
   "homepage": "http://snex.io",

--- a/src/__tests__/snex-test.js
+++ b/src/__tests__/snex-test.js
@@ -73,6 +73,37 @@ describe('SNEX Lib', () => {
         });
     });
 
+    describe('#joinSession', () => {
+        let peerMock, connMock;
+
+        beforeEach(() => {
+            connMock = new EventEmitter();
+
+            peerMock = new PeerMock();
+            peerMock.connect = sinon.spy(() => connMock);
+            promise = snex.joinSession('my-id', peerMock);
+        });
+
+        it('returns a promise', () => {
+            expect(promise).to.be.a(Promise);
+        })
+
+        it('calls Peer.connect with serialization set to json', () => {
+            expect(peerMock.connect.callCount).to.be(1);
+            expect(peerMock.connect.lastCall.args[0]).to.eql('my-id');
+            expect(peerMock.connect.lastCall.args[1]).to.eql({
+                serialization: 'json',
+            });
+        });
+
+        it('resolves a connection', () => {
+            connMock.emit('open');
+            return promise.then(conn => {
+                expect(conn).to.be(connMock);
+            });
+        });
+    });
+
     describe('Session', () => {
         let session, peerMock;
 

--- a/src/snex.js
+++ b/src/snex.js
@@ -68,7 +68,10 @@ function joinSession(id, peer = createPeer()) {
   return new Promise((resolve, reject) => {
     peer.on('error', reject);
 
-    const conn = peer.connect(id)
+    const conn = peer.connect(id, {
+      serialization: 'json',
+    });
+
     conn.on('open', () => {
       resolve(conn);
     });


### PR DESCRIPTION
Set serialization to `json` explicitly.

Fixes binary send bug in Safari.